### PR TITLE
Add uv packaging and faustaosay CLI entry point

### DIFF
--- a/faustaosay.py
+++ b/faustaosay.py
@@ -85,10 +85,18 @@ def faustao():
     return fausto
 
 
-if __name__ == '__main__':
-    stdin_input = ''
-    for line in sys.stdin:
-        stdin_input += line
+def main():
+    import os.path
+    import earley
 
-    print(generate_message_balloon(stdin_input.strip('\n'), 30))
+    grammar_file = os.path.join(os.path.dirname(__file__), 'grammars', 'fausto.gr')
+    initial, variables, terminals, rules = earley.read_file(grammar_file)
+    sentence = earley.generate_random(initial, variables, terminals, rules, False)
+    message = sentence[0].upper() + sentence[1:] if sentence else sentence
+
+    print(generate_message_balloon(message, 30))
     print(faustao())
+
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "faustaosay"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+audio = ["playsound"]
+
+[project.scripts]
+faustaosay = "faustaosay:main"
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "faustaosay.py",
+    "earley.py",
+    "generator.py",
+    "parser.py",
+    "grammars/",
+    "fausto.cow",
+]


### PR DESCRIPTION
Adds pyproject.toml with hatchling build backend so the project can be installed as a uv tool.

Adds a main() entry point to faustaosay.py that auto-generates a random sentence from the Fausto grammar and displays it cowsay-style.

Install and run with:
    `uv tool install .`
    `faustaosay`