### PR TITLE
feat: parallelize audio playback with ASCII art display

### DIFF
--- a/faustaosay.py
+++ b/faustaosay.py
@@ -89,9 +89,12 @@ def main():
     import os.path
     import earley
 
-    grammar_file = os.path.join(os.path.dirname(__file__), 'grammars', 'fausto.gr')
-    initial, variables, terminals, rules = earley.read_file(grammar_file)
-    sentence = earley.generate_random(initial, variables, terminals, rules, False)
+    if not sys.stdin.isatty():
+        sentence = sys.stdin.readline().strip()
+    else:
+        grammar_file = os.path.join(os.path.dirname(__file__), 'grammars', 'fausto.gr')
+        initial, variables, terminals, rules = earley.read_file(grammar_file)
+        sentence = earley.generate_random(initial, variables, terminals, rules, False)
     message = sentence[0].upper() + sentence[1:] if sentence else sentence
 
     print(generate_message_balloon(message, 30))

--- a/generator.py
+++ b/generator.py
@@ -3,6 +3,7 @@
 import sys
 import argparse
 import os.path
+import threading
 import earley
 
 import importlib.util
@@ -67,11 +68,17 @@ def main(grammar_file, audio_dir=""):
     sentence = earley.generate_random(
         initial, variables, terminals, rules, False)
 
+    audio_thread = None
     if len(audio_dir) != 0 and has_audio:
-        if not handle_audio(sentence, audio_dir):
-            return -3
+        audio_thread = threading.Thread(
+            target=handle_audio, args=(sentence, audio_dir), daemon=True)
+        audio_thread.start()
 
     print(format_sentence(sentence))
+    sys.stdout.flush()
+
+    if audio_thread is not None:
+        audio_thread.join()
 
     return 0
 


### PR DESCRIPTION
## Summary

- Start audio playback in a background thread in `generator.py` so the sentence is written to stdout immediately, instead of blocking until all audio finishes
- `faustaosay.py` now renders the balloon and ASCII art concurrently with audio playing in `generator.py`
- Fix `faustaosay.py` to read from stdin when being piped, so it uses the same sentence the generator produced (previously it ignored the pipe and generated its own independent sentence)

## How it works

Before this change the timeline looked like:
```
generator.py:  [generate] ---[audio plays]--- [print sentence]
faustaosay.py:                                               [read stdin] [render]
```

After:
```
generator.py:  [generate] [start audio thread] [print sentence] ---[audio plays]---[done]
                                                       ↓
faustaosay.py:                               [read stdin] [render balloon + ASCII art]
```

## Test plan

- [ ] Run `./generator.py -f ./audios/fausto/ -g ./grammars/fausto.gr | ./faustaosay.py` and confirm the ASCII art appears immediately while audio plays in the background
- [ ] Run `./faustaosay.py` standalone (no pipe) and confirm it still generates and displays its own sentence
- [ ] Run `./generator.py -g ./grammars/fausto.gr` (no audio) and confirm it still works without the audio flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)